### PR TITLE
Remove prefixo das URLs de requesição

### DIFF
--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -170,7 +170,7 @@ export default class MainLayout extends Component {
                         </SubMenu>
                         {isCuradorOuOperador() ? (
                             <Menu.Item key="16">
-                                <a href={`${baseUrl}/api/darwincore`} target="_blank" rel="noreferrer">
+                                <a href={`${baseUrl}/darwincore`} target="_blank" rel="noreferrer">
                                     <DesktopOutlined />
                                     <span>Darwin Core</span>
                                 </a>

--- a/src/pages/DetalhesTomboScreen.jsx
+++ b/src/pages/DetalhesTomboScreen.jsx
@@ -40,7 +40,7 @@ export default class DetalhesTomboScreen extends Component {
     }
 
     requisitaTombo = () => {
-        axios.get(`/api/tombos/${this.props.match.params.tombo_id}`)
+        axios.get(`/tombos/${this.props.match.params.tombo_id}`)
             .then(response => {
                 if (response.status === 200) {
                     this.setState({

--- a/src/pages/FichaTomboScreen.jsx
+++ b/src/pages/FichaTomboScreen.jsx
@@ -47,7 +47,7 @@ class FichaTomboScreen extends Component {
     }
 
     geraColunaAcao = tombo => (
-        <a target="_blank" rel="noreferrer" href={`${baseUrl}/api/fichas/tombos/${tombo.hcf}`} title="Imprimir ficha">
+        <a target="_blank" rel="noreferrer" href={`${baseUrl}/fichas/tombos/${tombo.hcf}`} title="Imprimir ficha">
             <PrinterOutlined style={{ color: '#277a01' }} />
         </a>
     )

--- a/src/pages/ListaHerbariosScreen.jsx
+++ b/src/pages/ListaHerbariosScreen.jsx
@@ -85,7 +85,7 @@ class ListaHerbariosScreen extends Component {
     }
 
     requisitaExclusao(id) {
-        axios.delete(`/api/herbarios/${id}`)
+        axios.delete(`/herbarios/${id}`)
             .then(response => {
                 if (response.status === 204) {
                     this.requisitaListaHerbarios(this.state.valores, this.state.pagina)

--- a/src/pages/ListaPendenciasScreen.jsx
+++ b/src/pages/ListaPendenciasScreen.jsx
@@ -61,7 +61,7 @@ class ListaPendenciasScreen extends Component {
     }
 
     requisitaExclusao(id) {
-        axios.delete(`/api/pendencias/${id}`)
+        axios.delete(`/pendencias/${id}`)
             .then(response => {
                 if (response.status === 204) {
                     this.requisitaListaPendencias(this.state.valores, this.state.pagina)

--- a/src/pages/ListaRemessasScreen.jsx
+++ b/src/pages/ListaRemessasScreen.jsx
@@ -156,7 +156,7 @@ class ListaRemessasScreen extends Component {
     }
 
     requisitaExclusao(id) {
-        axios.delete(`/api/remessas/${id}`)
+        axios.delete(`/remessas/${id}`)
             .then(response => {
                 if (response.status === 204) {
                     this.requisitaListaRemessas(this.state.valores, this.state.pagina)

--- a/src/pages/ListaTaxonomiaAutores.jsx
+++ b/src/pages/ListaTaxonomiaAutores.jsx
@@ -49,7 +49,7 @@ class ListaTaxonomiaAutores extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/autores/${id}`)
+        axios.delete(`/autores/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -205,7 +205,7 @@ class ListaTaxonomiaAutores extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/autores/', {
+        axios.post('/autores', {
             nome: this.props.form.getFieldsValue().nomeAutor,
             iniciais: this.props.form.getFieldsValue().nomeIniciais
         })
@@ -266,7 +266,7 @@ class ListaTaxonomiaAutores extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/autores/${this.state.id}`, {
+        axios.put(`/autores/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeAutor,
             iniciais: this.props.form.getFieldsValue().nomeIniciais
         })

--- a/src/pages/ListaTaxonomiaEspecie.jsx
+++ b/src/pages/ListaTaxonomiaEspecie.jsx
@@ -50,7 +50,7 @@ class ListaTaxonomiaEspecie extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/especies/${id}`)
+        axios.delete(`/especies/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -216,7 +216,7 @@ class ListaTaxonomiaEspecie extends Component {
     }
 
     requisitaAutores = () => {
-        axios.get('/autores/', {
+        axios.get('/autores', {
             params: {
                 limite: 9999999
             }
@@ -246,7 +246,7 @@ class ListaTaxonomiaEspecie extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/especies/', {
+        axios.post('/especies', {
             nome: this.props.form.getFieldsValue().nomeEspecie,
             genero_id: this.props.form.getFieldsValue().nomeGenero,
             autor_id: this.props.form.getFieldsValue().nomeAutor
@@ -288,7 +288,7 @@ class ListaTaxonomiaEspecie extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/especies/${this.state.id}`, {
+        axios.put(`/especies/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeEspecie,
             genero_id: this.props.form.getFieldsValue().nomeGenero,
             autor_id: this.props.form.getFieldsValue().nomeAutor
@@ -327,7 +327,7 @@ class ListaTaxonomiaEspecie extends Component {
     }
 
     requisitaGeneros = () => {
-        axios.get('/generos/', {
+        axios.get('/generos', {
             params: {
                 limite: 9999999
             }

--- a/src/pages/ListaTaxonomiaFamilia.jsx
+++ b/src/pages/ListaTaxonomiaFamilia.jsx
@@ -47,7 +47,7 @@ class ListaTaxonomiaFamilia extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/familias/${id}`)
+        axios.delete(`/familias/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -200,7 +200,7 @@ class ListaTaxonomiaFamilia extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/familias/', {
+        axios.post('/familias', {
             nome: this.props.form.getFieldsValue().nomeFamilia
         })
             .then(response => {
@@ -238,7 +238,7 @@ class ListaTaxonomiaFamilia extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/familias/${this.state.id}`, {
+        axios.put(`/familias/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeFamilia
         })
             .then(response => {

--- a/src/pages/ListaTaxonomiaGenero.jsx
+++ b/src/pages/ListaTaxonomiaGenero.jsx
@@ -49,7 +49,7 @@ class ListaTaxonomiaGenero extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/generos/${id}`)
+        axios.delete(`/generos/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -231,7 +231,7 @@ class ListaTaxonomiaGenero extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/generos/', {
+        axios.post('/generos', {
             nome: this.props.form.getFieldsValue().nomeGenero,
             familia_id: this.props.form.getFieldsValue().nomeFamilia
         })
@@ -270,7 +270,7 @@ class ListaTaxonomiaGenero extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/generos/${this.state.id}`, {
+        axios.put(`/generos/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeGenero,
             familia_id: this.props.form.getFieldsValue().nomeFamilia
         })
@@ -306,7 +306,7 @@ class ListaTaxonomiaGenero extends Component {
     }
 
     requisitaFamilias = () => {
-        axios.get('/familias/', {
+        axios.get('/familias', {
             params: {
                 limite: 9999999
             }

--- a/src/pages/ListaTaxonomiaScreen.jsx
+++ b/src/pages/ListaTaxonomiaScreen.jsx
@@ -65,7 +65,7 @@ class ListaTaxonomiaScreen extends Component {
     }
 
     requisitaExclusao(id) {
-        axios.delete(`/api/taxonomias/${id}`)
+        axios.delete(`/taxonomias/${id}`)
             .then(response => {
                 if (response.status === 204) {
                     this.requisitaListaTaxonomias(this.state.valores, this.state.pagina)

--- a/src/pages/ListaTaxonomiaSubespecie.jsx
+++ b/src/pages/ListaTaxonomiaSubespecie.jsx
@@ -50,7 +50,7 @@ class ListaTaxonomiaSubespecie extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/subespecies/${id}`)
+        axios.delete(`/subespecies/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -236,7 +236,7 @@ class ListaTaxonomiaSubespecie extends Component {
     }
 
     requisitaAutores = () => {
-        axios.get('/autores/', {
+        axios.get('/autores', {
             params: {
                 limite: 9999999
             }
@@ -266,7 +266,7 @@ class ListaTaxonomiaSubespecie extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/subespecies/', {
+        axios.post('/subespecies', {
             nome: this.props.form.getFieldsValue().nomeSubespecie,
             especie_id: this.props.form.getFieldsValue().nomeEspecie,
             autor_id: this.props.form.getFieldsValue().nomeAutor
@@ -308,7 +308,7 @@ class ListaTaxonomiaSubespecie extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/subespecies/${this.state.id}`, {
+        axios.put(`/subespecies/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeSubespecie,
             especie_id: this.props.form.getFieldsValue().nomeEspecie,
             autor_id: this.props.form.getFieldsValue().nomeAutor
@@ -347,7 +347,7 @@ class ListaTaxonomiaSubespecie extends Component {
     }
 
     requisitaEspecies = () => {
-        axios.get('/especies/', {
+        axios.get('/especies', {
             params: {
                 limite: 9999999
             }

--- a/src/pages/ListaTaxonomiaSubfamilia.jsx
+++ b/src/pages/ListaTaxonomiaSubfamilia.jsx
@@ -49,7 +49,7 @@ class ListaTaxonomiaSubfamilia extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/subfamilias/${id}`)
+        axios.delete(`/subfamilias/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -208,7 +208,7 @@ class ListaTaxonomiaSubfamilia extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/subfamilias/', {
+        axios.post('/subfamilias', {
             nome: this.props.form.getFieldsValue().nomeSubfamilia,
             familia_id: this.props.form.getFieldsValue().nomeFamilia
         })
@@ -247,7 +247,7 @@ class ListaTaxonomiaSubfamilia extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/subfamilias/${this.state.id}`, {
+        axios.put(`/subfamilias/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeSubfamilia,
             familia_id: this.props.form.getFieldsValue().nomeFamilia
         })
@@ -306,7 +306,7 @@ class ListaTaxonomiaSubfamilia extends Component {
     }
 
     requisitaFamilias = () => {
-        axios.get('/familias/', {
+        axios.get('/familias', {
             params: {
                 limite: 9999999
             }

--- a/src/pages/ListaTaxonomiaVariedade.jsx
+++ b/src/pages/ListaTaxonomiaVariedade.jsx
@@ -50,7 +50,7 @@ class ListaTaxonomiaVariedade extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/variedades/${id}`)
+        axios.delete(`/variedades/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -214,7 +214,7 @@ class ListaTaxonomiaVariedade extends Component {
     }
 
     requisitaAutores = () => {
-        axios.get('/autores/', {
+        axios.get('/autores', {
             params: {
                 limite: 9999999
             }
@@ -266,7 +266,7 @@ class ListaTaxonomiaVariedade extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/variedades/', {
+        axios.post('/variedades', {
             nome: this.props.form.getFieldsValue().nomeVariedade,
             especie_id: this.props.form.getFieldsValue().nomeEspecie,
             autor_id: this.props.form.getFieldsValue().nomeAutor
@@ -308,7 +308,7 @@ class ListaTaxonomiaVariedade extends Component {
         this.setState({
             loading: true
         })
-        axios.put(`/api/variedades/${this.state.id}`, {
+        axios.put(`/variedades/${this.state.id}`, {
             nome: this.props.form.getFieldsValue().nomeVariedade,
             especie_id: this.props.form.getFieldsValue().nomeEspecie,
             autor_id: this.props.form.getFieldsValue().nomeAutor
@@ -347,7 +347,7 @@ class ListaTaxonomiaVariedade extends Component {
     }
 
     requisitaEspecies = () => {
-        axios.get('/especies/', {
+        axios.get('/especies', {
             params: {
                 limite: 9999999
             }

--- a/src/pages/ListaTombosScreen.jsx
+++ b/src/pages/ListaTombosScreen.jsx
@@ -76,7 +76,7 @@ class ListaTombosScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.delete(`/api/tombos/${id}`)
+        axios.delete(`/tombos/${id}`)
             .then(response => {
                 this.setState({
                     loading: false
@@ -493,7 +493,7 @@ class ListaTombosScreen extends Component {
             })
             .reduce((filtros, [chave, valor]) => ({ ...filtros, [chave]: valor }), {})
 
-        const url = `${baseUrl}/api/tombos/exportar?campos=${JSON.stringify(campos)}&filtros=${JSON.stringify(filtros)}`
+        const url = `${baseUrl}/tombos/exportar?campos=${JSON.stringify(campos)}&filtros=${JSON.stringify(filtros)}`
         window.open(url, '_blank')
     }
 
@@ -508,7 +508,7 @@ class ListaTombosScreen extends Component {
         this.lastFetchId += 1
         const fetchId = this.lastFetchId
         this.setState({ data: [], fetching: true })
-        axios.get(`/api/tombos/filtrar_numero/${value}`)
+        axios.get(`/tombos/filtrar_numero/${value}`)
             .then(response => {
                 if (response.status === 200) {
                     if (fetchId !== this.lastFetchId) { // for fetch callback order

--- a/src/pages/ListaUsuariosScreen.jsx
+++ b/src/pages/ListaUsuariosScreen.jsx
@@ -64,7 +64,7 @@ class ListaUsuariosScreen extends Component {
     }
 
     requisitaExclusao(id) {
-        axios.delete(`/api/usuarios/${id}`)
+        axios.delete(`/usuarios/${id}`)
             .then(response => {
                 if (response.status === 204) {
                     this.requisitaListaUsuarios(this.state.valores, this.state.pagina)

--- a/src/pages/NovaRemessaScreen.jsx
+++ b/src/pages/NovaRemessaScreen.jsx
@@ -76,7 +76,7 @@ class NovaRemessaScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get(`/api/remessas/${this.props.match.params.remessa_id}`)
+        axios.get(`/remessas/${this.props.match.params.remessa_id}`)
             .then(response => {
                 if (response.status === 200) {
                     this.setState({
@@ -127,7 +127,7 @@ class NovaRemessaScreen extends Component {
             loading: true
         })
 
-        axios.get('/herbarios/', {
+        axios.get('/herbarios', {
             params: {
                 limite: 9999999
             }
@@ -188,7 +188,7 @@ class NovaRemessaScreen extends Component {
             doador
         } = valores
 
-        axios.post('/remessas/', {
+        axios.post('/remessas', {
             remessa: {
                 observacao: observacoes,
                 data_envio: dataEnvio,
@@ -240,7 +240,7 @@ class NovaRemessaScreen extends Component {
             receptor,
             doador
         } = valores
-        axios.put(`/api/remessas/${this.props.match.params.remessa_id}`, {
+        axios.put(`/remessas/${this.props.match.params.remessa_id}`, {
             remessa: {
                 observacao: observacoes,
                 data_envio: dataEnvio,

--- a/src/pages/NovoHerbarioScreen.jsx
+++ b/src/pages/NovoHerbarioScreen.jsx
@@ -44,7 +44,7 @@ class NovoHerbarioScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/paises/')
+        axios.get('/paises')
             .then(response => {
                 this.setState({
                     loading: false
@@ -81,7 +81,7 @@ class NovoHerbarioScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/estados/', {
+        axios.get('/estados', {
             params: {
                 id
             }
@@ -122,7 +122,7 @@ class NovoHerbarioScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/cidades/', {
+        axios.get('/cidades', {
             params: {
                 id
             }
@@ -253,7 +253,7 @@ class NovoHerbarioScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get(`/api/herbarios/${this.props.match.params.herbario_id}`)
+        axios.get(`/herbarios/${this.props.match.params.herbario_id}`)
             .then(response => {
                 const {
                     nome, email, sigla, endereco
@@ -335,7 +335,7 @@ class NovoHerbarioScreen extends Component {
         if (numero) json.endereco.numero = numero
         if (complemento) json.endereco.complemento = complemento
 
-        axios.put(`/api/herbarios/${this.props.match.params.herbario_id}`, json)
+        axios.put(`/herbarios/${this.props.match.params.herbario_id}`, json)
             .then(response => {
                 this.setState({
                     loading: false

--- a/src/pages/NovoTomboScreen.jsx
+++ b/src/pages/NovoTomboScreen.jsx
@@ -131,7 +131,7 @@ class NovoTomboScreen extends Component {
     }
 
     requisitaDadosEdicao = id => {
-        axios.get(`/api/tombos/${id}`)
+        axios.get(`/tombos/${id}`)
             .then(response => {
                 if (response.status === 200) {
                     const { data } = response
@@ -360,7 +360,7 @@ class NovoTomboScreen extends Component {
             if (variedade) {
                 json.variedade_id = variedade
             }
-            axios.put(`/api/tombos/${this.props.match.params.tombo_id}`, json)
+            axios.put(`/tombos/${this.props.match.params.tombo_id}`, json)
                 .then(response => {
                     this.setState({
                         loading: false
@@ -613,7 +613,7 @@ class NovoTomboScreen extends Component {
     ))
 
     requisitaEstados = id => {
-        axios.get('/estados/', {
+        axios.get('/estados', {
             params: {
                 id
             }
@@ -640,7 +640,7 @@ class NovoTomboScreen extends Component {
     }
 
     requisitaCidades = id => {
-        axios.get('/cidades/', {
+        axios.get('/cidades', {
             params: {
                 id
             }
@@ -678,7 +678,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/tipos/', {
+        axios.post('/tipos', {
             nome: this.props.form.getFieldsValue().campo
         })
             .then(response => {
@@ -719,7 +719,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/tipos/')
+        axios.get('/tipos')
             .then(response => {
                 this.setState({
                     loading: false
@@ -756,7 +756,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/familias/', {
+        axios.post('/familias', {
             nome: this.props.form.getFieldsValue().campo
         })
             .then(response => {
@@ -797,7 +797,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/familias/', {
+        axios.get('/familias', {
             params: {
                 limite: 9999999999
             }
@@ -841,7 +841,7 @@ class NovoTomboScreen extends Component {
             this.setState({
                 loading: true
             })
-            axios.post('/subfamilias/', {
+            axios.post('/subfamilias', {
                 nome: this.props.form.getFieldsValue().campo,
                 familia_id: this.props.form.getFieldsValue().familia
             })
@@ -889,7 +889,7 @@ class NovoTomboScreen extends Component {
         // this.setState({
         //     loading: true,
         // });
-        axios.get('/subfamilias/', {
+        axios.get('/subfamilias', {
             params: {
                 familia_id: id,
                 limite: 999999999
@@ -942,7 +942,7 @@ class NovoTomboScreen extends Component {
             this.setState({
                 loading: true
             })
-            axios.post('/generos/', {
+            axios.post('/generos', {
                 nome: this.props.form.getFieldsValue().campo,
                 familia_id: this.props.form.getFieldsValue().familia
             })
@@ -990,7 +990,7 @@ class NovoTomboScreen extends Component {
         // this.setState({
         //     loading: true,
         // });
-        axios.get('/generos/', {
+        axios.get('/generos', {
             params: {
                 familia_id: id,
                 limite: 9999999999
@@ -1042,7 +1042,7 @@ class NovoTomboScreen extends Component {
             this.setState({
                 loading: true
             })
-            axios.post('/especies/', {
+            axios.post('/especies', {
                 nome: this.props.form.getFieldsValue().campo,
                 familia_id: this.props.form.getFieldsValue().familia,
                 genero_id: this.props.form.getFieldsValue().genero,
@@ -1092,7 +1092,7 @@ class NovoTomboScreen extends Component {
         // this.setState({
         //     loading: true,
         // });
-        axios.get('/especies/', {
+        axios.get('/especies', {
             params: {
                 genero_id: id,
                 limite: 9999999999
@@ -1149,7 +1149,7 @@ class NovoTomboScreen extends Component {
             this.setState({
                 loading: true
             })
-            axios.post('/subespecies/', {
+            axios.post('/subespecies', {
                 nome: this.props.form.getFieldsValue().campo,
                 familia_id: this.props.form.getFieldsValue().familia,
                 genero_id: this.props.form.getFieldsValue().genero,
@@ -1200,7 +1200,7 @@ class NovoTomboScreen extends Component {
         // this.setState({
         //     loading: true,
         // });
-        axios.get('/subespecies/', {
+        axios.get('/subespecies', {
             params: {
                 especie_id: id,
                 limite: 999999999
@@ -1255,7 +1255,7 @@ class NovoTomboScreen extends Component {
             this.setState({
                 loading: true
             })
-            axios.post('/variedades/', {
+            axios.post('/variedades', {
                 nome: this.props.form.getFieldsValue().campo,
                 familia_id: this.props.form.getFieldsValue().familia,
                 genero_id: this.props.form.getFieldsValue().genero,
@@ -1306,7 +1306,7 @@ class NovoTomboScreen extends Component {
         // this.setState({
         //     loading: true,
         // });
-        axios.get('/variedades/', {
+        axios.get('/variedades', {
             params: {
                 especie_id: id,
                 limite: 999999999
@@ -1349,7 +1349,7 @@ class NovoTomboScreen extends Component {
     }
 
     cadastraNovoAutor() {
-        axios.post('/autores/', {
+        axios.post('/autores', {
             nome: this.props.form.getFieldsValue().campo,
             iniciais: ''
         })
@@ -1389,7 +1389,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/autores/')
+        axios.get('/autores')
             .then(response => {
                 this.setState({
                     loading: false
@@ -1432,7 +1432,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/solos/', {
+        axios.post('/solos', {
             nome: this.props.form.getFieldsValue().campo
         })
             .then(response => {
@@ -1476,7 +1476,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/solos/')
+        axios.get('/solos')
             .then(response => {
                 this.setState({
                     loading: false
@@ -1519,7 +1519,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/relevos/', {
+        axios.post('/relevos', {
             nome: this.props.form.getFieldsValue().campo
         })
             .then(response => {
@@ -1569,7 +1569,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/relevos/')
+        axios.get('/relevos')
             .then(response => {
                 this.setState({
                     loading: false
@@ -1612,7 +1612,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.post('/vegetacoes/', {
+        axios.post('/vegetacoes', {
             nome: this.props.form.getFieldsValue().campo
         })
             .then(response => {
@@ -1658,7 +1658,7 @@ class NovoTomboScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get('/vegetacoes/')
+        axios.get('/vegetacoes')
             .then(response => {
                 this.setState({
                     loading: false
@@ -1704,7 +1704,7 @@ class NovoTomboScreen extends Component {
             formColetor: false,
             loading: true
         })
-        axios.post('/coletores/', {
+        axios.post('/coletores', {
             nome: this.props.form.getFieldsValue().nomeColetor,
             email: this.props.form.getFieldsValue().emailColetor,
             numero: this.props.form.getFieldsValue().numeroColetor
@@ -1759,7 +1759,7 @@ class NovoTomboScreen extends Component {
             coletores: [],
             fetchingColetores: true
         })
-        axios.get(`/api/coletores-predicao?nome=${nome}`)
+        axios.get(`/coletores-predicao?nome=${nome}`)
             .then(response => {
                 if (response.status === 200) {
                     this.setState({
@@ -1790,7 +1790,7 @@ class NovoTomboScreen extends Component {
             identificadores: [],
             fetchingIdentificadores: true
         })
-        axios.get(`/api/identificadores-predicao?nome=${nome}`)
+        axios.get(`/identificadores-predicao?nome=${nome}`)
             .then(response => {
                 if (response.status === 200) {
                     this.setState({

--- a/src/pages/NovoUsuarioScreen.jsx
+++ b/src/pages/NovoUsuarioScreen.jsx
@@ -110,7 +110,7 @@ class NovoUsuarioScreen extends Component {
     }
 
     requisitaUsuario = () => {
-        axios.get(`/api/usuarios/${this.props.match.params.usuario_id}`)
+        axios.get(`/usuarios/${this.props.match.params.usuario_id}`)
             .then(response => {
                 if (response.data && response.status === 200) {
                     this.props.form.setFields({
@@ -175,7 +175,7 @@ class NovoUsuarioScreen extends Component {
         if (valores.password != null && valores.password.trim() != '') {
             body.senha = password
         }
-        axios.put(`/api/usuarios/${this.props.match.params.usuario_id}`, body)
+        axios.put(`/usuarios/${this.props.match.params.usuario_id}`, body)
             .then(response => {
                 if (response.status !== 201 && response.status !== 204) {
                     this.openNotificationWithIcon('error', 'Edição', 'Houve um problema ao realizar a edição, verifique os dados e tente novamente.')

--- a/src/pages/VerPendenciaScreen.jsx
+++ b/src/pages/VerPendenciaScreen.jsx
@@ -58,7 +58,7 @@ class VerPendenciaScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.get(`/api/pendencias/${this.props.match.params.pendencia_id}`)
+        axios.get(`/pendencias/${this.props.match.params.pendencia_id}`)
             .then(response => {
                 if (response.status === 200) {
                     this.setState({
@@ -102,7 +102,7 @@ class VerPendenciaScreen extends Component {
         this.setState({
             loading: true
         })
-        axios.post(`/api/pendencias/${this.props.match.params.pendencia_id}`, { observacao, status: this.state.aprovar })
+        axios.post(`/pendencias/${this.props.match.params.pendencia_id}`, { observacao, status: this.state.aprovar })
             .then(response => {
                 this.setState({
                     loading: false


### PR DESCRIPTION
Removido prefixo `/api/` das URLs.

- No ambiente local este prefixo é adicionado através da variável de ambiente.
- No ambiente de produção não existe este prefixo, pois virou subdomínio `api.`

![image](https://github.com/utfpr/hcf-painel/assets/3211168/3b31f457-37df-44d1-b025-de854c006d26)

