### PR TITLE
fix(novo-tombo-screen): adjust the formdata object to send the images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:3000/api
+
+VITE_IMAGE_BASE_URL=http://localhost:3000

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,4 +1,4 @@
-export const baseUrl = import.meta.env.VITE_API_URL
+export const baseUrl = import.meta.env.VITE_IMAGE_BASE_URL
 
 export const fotosBaseUrl = `${baseUrl}/fotos`
 

--- a/src/helpers/fotos-tombo-map.js
+++ b/src/helpers/fotos-tombo-map.js
@@ -1,6 +1,6 @@
 import { fotosBaseUrl } from '../config/api'
 
 export default foto => ({
-    original: `${fotosBaseUrl}/${foto.original}`,
-    thumbnail: `${fotosBaseUrl}/${foto.thumbnail}`
+    original: `${fotosBaseUrl}/${foto.original}`.replace('api/', ''),
+    thumbnail: `${fotosBaseUrl}/${foto.thumbnail}`.replace('api/', '')
 })

--- a/src/helpers/fotos-tombo-map.js
+++ b/src/helpers/fotos-tombo-map.js
@@ -1,6 +1,6 @@
 import { fotosBaseUrl } from '../config/api'
 
 export default foto => ({
-    original: `${fotosBaseUrl}/${foto.original}`.replace('api/', ''),
-    thumbnail: `${fotosBaseUrl}/${foto.thumbnail}`.replace('api/', '')
+    original: `${fotosBaseUrl}/${foto.original}`,
+    thumbnail: `${fotosBaseUrl}/${foto.thumbnail}`
 })

--- a/src/pages/NovoTomboScreen.jsx
+++ b/src/pages/NovoTomboScreen.jsx
@@ -477,7 +477,7 @@ class NovoTomboScreen extends Component {
                         form.append('tombo_hcf', hcf)
                         form.append('em_vivo', emVivo)
 
-                        return axios.post('/uploads', {
+                        return axios.post('/uploads', form, {
                             headers: {
                                 'Content-Type': 'multipart/form-data'
                             }


### PR DESCRIPTION
# Description

- adjust the path for image mapping to show images on collection details
- adjust the formdata object to send the images on collection creation 

## Type of change

- [ ] Fix

# How Has This Been Tested?

- [ ] A test image was placed in the virtual path created by express on backend and accessed via the frontend
- [ ] Created a test collection and added a test image for upload
- [ ] Details were viewed with the previously created test collection
- [ ] Created new types of families, genus, species, and so on
- [ ] Viewed the details of the collections and checked whether the new types were applied to the new collection created