### PR TITLE
chore(ficha-tombo): adjust the button icons on the sheet screen

### DIFF
--- a/src/pages/FichaTomboScreen.jsx
+++ b/src/pages/FichaTomboScreen.jsx
@@ -7,7 +7,7 @@ import {
 import axios from 'axios'
 
 import { Form } from '@ant-design/compatible'
-import { PrinterOutlined } from '@ant-design/icons'
+import { PrinterOutlined, SearchOutlined } from '@ant-design/icons'
 
 import SimpleTableComponent from '../components/SimpleTableComponent'
 import { baseUrl } from '../config/api'
@@ -139,7 +139,7 @@ class FichaTomboScreen extends Component {
                 </Row>
                 <Row gutter="8">
                     <Col span="24">
-                        <Button type="primary" htmlType="submit" icon="search">
+                        <Button type="primary" htmlType="submit" icon={<SearchOutlined />}>
                             Pesquisar
                         </Button>
                     </Col>


### PR DESCRIPTION
# Description

Fix the import of the collection sheet screen button icon

## Type of change

- [x] Bug fix

# How Has This Been Tested?

- [x] Checked that the icon appears correctly

# Screenshots
  
<details>
  <summary>Desktop</summary>
  
  ![image](https://github.com/utfpr/hcf-painel/assets/66524335/5980da87-34f3-48fb-a9f3-4f3682dc6c3f)
</details>