### PR TITLE
fix(detalhes-tombos): fix the image path

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "@types/node": "18.11.9",
         "@types/react": "18.2.28",
         "@types/react-dom": "18.2.13",
+        "@types/react-image-gallery": "^1.2.4",
         "@typescript-eslint/eslint-plugin": "6.7.5",
         "@typescript-eslint/parser": "6.7.5",
         "@vitejs/plugin-react": "4.1.0",

--- a/src/components/GalleryComponent.jsx
+++ b/src/components/GalleryComponent.jsx
@@ -3,7 +3,24 @@ import { Component } from 'react'
 import ImageGallery from 'react-image-gallery'
 
 export default class GalleryComponent extends Component {
+    handleClick = () => {
+        if (this.props.fotos.length > 0) window.open(this.props.fotos[0].original, '_blank')
+    }
+
+    handleImageError = e => {
+        e.target.src = 'https://t4.ftcdn.net/jpg/01/39/16/63/240_F_139166369_NdTDXc0lM57N66868lC66PpsaMkFSwaf.jpg'
+    }
+
     render() {
-        return <ImageGallery items={this.props.fotos} />
+        return (
+            <ImageGallery
+                items={this.props.fotos}
+                showPlayButton={false}
+                showFullscreenButton={false}
+                showThumbnails={this.props.fotos.length > 1}
+                onClick={this.handleClick}
+                onImageError={this.handleImageError}
+            />
+        )
     }
 }

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,5 +1,5 @@
 export const baseUrl = import.meta.env.VITE_IMAGE_BASE_URL
 
-export const fotosBaseUrl = `${baseUrl}/fotos`
+export const fotosBaseUrl = `${baseUrl}`
 
 export default {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-image-gallery@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/react-image-gallery/-/react-image-gallery-1.2.4.tgz#17c2e3416a5c9ecab14588eac593d4a7aa583163"
+  integrity sha512-H0xpmT5rlSH0qiTvcUDCPDLRBi3J3Xa4COqaDqGb7ffLFpQoPAxpZdNuKCuThhFI0xJmNnMubZiD6B3kCBHtcw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@18.2.28":
   version "18.2.28"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.28.tgz#86877465c0fcf751659a36c769ecedfcfacee332"


### PR DESCRIPTION
# Description

Adjusts paths to images and handles when they don't exist

## Type of change

Please delete options that are not relevant.

- [x] Chore

# How Has This Been Tested?

- [x] Checked that the image appears when I enter the collections details screen
- [x] Checks if the callback image appears when the images are broken

# Screenshots

<details>
  <summary>Desktop</summary>
  
  ![image](https://github.com/utfpr/hcf-painel/assets/66524335/fc7731ab-67ba-408a-9cf4-0616095b7a92)

![image](https://github.com/utfpr/hcf-painel/assets/66524335/4e9f68f1-d04d-4878-9f6b-2068280a5dfe)

</details>