### PR TITLE
Permissão do menu lateral

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,8 @@ import {
     setTokenUsuario,
     isCurador,
     isCuradorOuOperador,
-    isCuradorOuOperadorOuIdentificador
+    isCuradorOuOperadorOuIdentificador,
+    isLogado
 } from './helpers/usuarios'
 import MainLayout from './layouts/MainLayout'
 import DetalhesTomboScreen from './pages/DetalhesTomboScreen'
@@ -119,8 +120,8 @@ export default class App extends Component {
                 <PrivateRoute authed={isCurador()} path="/coletores/:coletor_id" component={NovoColetorScreen} />
                 <PrivateRoute authed={isCurador()} path="/coletores" component={ListaColetoresScreen} />
 
-                <Route path="/herbarios" component={ListaHerbariosScreen} />
-                <Route path="/fichas/tombos" component={FichaTomboScreen} />
+                <PrivateRoute authed={isLogado()} path="/herbarios" component={ListaHerbariosScreen} />
+                <PrivateRoute authed={isLogado()} path="/fichas/tombos" component={FichaTomboScreen} />
                 <PrivateRoute authed={isCurador()} path="/reflora" component={ServicosRefloraScreen} />
                 <PrivateRoute authed={isCurador()} path="/specieslink" component={ServicosSpeciesLinkScreen} />
 
@@ -136,8 +137,8 @@ export default class App extends Component {
                 <Route path="/mapa" component={Mapa} />
                 <Route path="/filtros" component={filtrosMapa} />
 
-                <Route path="/relatorio-inventario-especies" component={RelatorioInventarioEspeciesScreen} />
-                <Route path="/relatorio-coleta-local-data" component={RelatorioColetaLocalPeriodoScreen} />
+                <PrivateRoute authed={isLogado()} path="/relatorio-inventario-especies" component={RelatorioInventarioEspeciesScreen} />
+                <PrivateRoute authed={isLogado()} path="/relatorio-coleta-local-data" component={RelatorioColetaLocalPeriodoScreen} />
             </Switch>
         </MainLayout>
     )

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -188,27 +188,32 @@ export default class MainLayout extends Component {
                                 </Link>
                             </Menu.Item>
                         ) : null}
-                        <Menu.Item key="14">
-                            <Link to="/herbarios">
-                                <FlagOutlined />
-                                <span>Herbários</span>
-                            </Link>
-                        </Menu.Item>
-                        <SubMenu
-                            key="sub2"
-                            title={(
-                                <span>
-                                    <FileTextOutlined />
-                                    <span>Fichas</span>
-                                </span>
-                            )}
-                        >
-                            <Menu.Item key="15">
-                                {' '}
-                                <Link to="/fichas/tombos">Ficha tombo</Link>
-                                {' '}
+                        {isLogado() ? (
+                            <Menu.Item key="14">
+                                <Link to="/herbarios">
+                                    <FlagOutlined />
+                                    <span>Herbários</span>
+                                </Link>
                             </Menu.Item>
-                        </SubMenu>
+                        ) : null}
+                        {isLogado() ? (
+                            <SubMenu
+                                key="sub2"
+                                title={(
+                                    <span>
+                                        <FileTextOutlined />
+                                        <span>Fichas</span>
+                                    </span>
+                                )}
+                            >
+                                <Menu.Item key="15">
+                                    {' '}
+                                    <Link to="/fichas/tombos">Ficha tombo</Link>
+                                    {' '}
+                                </Menu.Item>
+                            </SubMenu>
+                        ) : null}
+
                         <SubMenu
                             key="sub3"
                             title={(
@@ -225,22 +230,25 @@ export default class MainLayout extends Component {
                                 <Link to="/filtros">Filtros Avançados</Link>
                             </Menu.Item>
                         </SubMenu>
-                        <SubMenu
-                            key="relatorios"
-                            title={(
-                                <span>
-                                    <SnippetsOutlined />
-                                    <span>Relatórios</span>
-                                </span>
-                            )}
-                        >
-                            <Menu.Item key="relatorio-inventario-especies">
-                                <Link to="/relatorio-inventario-especies">Inventário de Espécies</Link>
-                            </Menu.Item>
-                            <Menu.Item key="relatorio-coleta-local-data">
-                                <Link to="/relatorio-coleta-local-data">Coleta por local e intervalo de data</Link>
-                            </Menu.Item>
-                        </SubMenu>
+                        {isLogado() ? (
+                            <SubMenu
+                                key="relatorios"
+                                title={(
+                                    <span>
+                                        <SnippetsOutlined />
+                                        <span>Relatórios</span>
+                                    </span>
+                                )}
+                            >
+                                <Menu.Item key="relatorio-inventario-especies">
+                                    <Link to="/relatorio-inventario-especies">Inventário de Espécies</Link>
+                                </Menu.Item>
+                                <Menu.Item key="relatorio-coleta-local-data">
+                                    <Link to="/relatorio-coleta-local-data">Coleta por local e intervalo de data</Link>
+                                </Menu.Item>
+                            </SubMenu>
+                        ) : null}
+
                         {isCuradorOuOperador() ? (
                             <Menu.Item key="16">
                                 <a href={`${baseUrl}/darwincore`} target="_blank" rel="noreferrer">


### PR DESCRIPTION
Resolves [#112]
- Alterado as permissões de visualização do menu lateral para que usuários não logados acessem apenas área de listagem do tombo, taxonomia e geolocalização. 
- Proteção das páginas para usuários não acessarem páginas não autorizadas pela url.