### PR TITLE
refactor: coluna 'Reino' 

### DIFF
--- a/src/pages/ListaTaxonomiaEspecie.jsx
+++ b/src/pages/ListaTaxonomiaEspecie.jsx
@@ -28,14 +28,6 @@ const columns = [
         sorter: true
     },
     {
-        title: 'Reino',
-        type: 'text',
-        key: 'reino',
-        dataIndex: 'reino',
-        sorter: true,
-        width: '18.6%'
-    },
-    {
         title: 'Família',
         key: 'familia',
         dataIndex: 'familia',
@@ -190,7 +182,6 @@ class ListaTaxonomiaEspecie extends Component {
         acao: this.gerarAcao(item),
         genero: item.genero?.nome,
         familia: item.familia?.nome,
-        reino: item.reino?.nome,
         autor: item.autor?.nome
     }))
 

--- a/src/pages/ListaTaxonomiaGenero.jsx
+++ b/src/pages/ListaTaxonomiaGenero.jsx
@@ -28,14 +28,6 @@ const columns = [
         width: '30.4%'
     },
     {
-        title: 'Reino',
-        type: 'text',
-        key: 'reino',
-        dataIndex: 'reino',
-        sorter: true,
-        width: '30.4%'
-    },
-    {
         title: 'Família',
         type: 'text',
         key: 'familia',
@@ -57,7 +49,6 @@ class ListaTaxonomiaGenero extends Component {
             generos: [],
             metadados: {},
             familias: [],
-            reinos: [],
             pagina: 1,
             visibleModal: false,
             loadingModal: false,
@@ -119,29 +110,6 @@ class ListaTaxonomiaGenero extends Component {
     componentDidMount() {
         this.requisitaListaGenero({}, this.state.pagina)
         this.requisitaFamilias()
-        this.requisitaReinos()
-    }
-
-    requisitaReinos = () => {
-        axios.get('/reinos', {
-            params: {
-                limite: 9999999
-            }
-        })
-            .then(response => {
-                if (response.status === 200) {
-                    this.setState({
-                        reinos: response.data.resultado
-                    })
-                }
-            })
-            .catch(err => {
-                const { response } = err
-                if (response && response.data) {
-                    const { error } = response.data
-                    console.error(error.message)
-                }
-            })
     }
 
     gerarAcao(item) {
@@ -192,7 +160,6 @@ class ListaTaxonomiaGenero extends Component {
         genero: item.nome,
         acao: this.gerarAcao(item),
         familia: item.familia?.nome,
-        reino: item.reino?.nome
     }))
 
     renderAdd = () => {
@@ -465,10 +432,6 @@ class ListaTaxonomiaGenero extends Component {
     }
 
     optionFamilia = () => this.state.familias.map(item => (
-        <Option value={item.id}>{item.nome}</Option>
-    ))
-
-    optionReino = () => this.state.reinos.map(item => (
         <Option value={item.id}>{item.nome}</Option>
     ))
 

--- a/src/pages/ListaTaxonomiaSubespecie.jsx
+++ b/src/pages/ListaTaxonomiaSubespecie.jsx
@@ -28,14 +28,6 @@ const columns = [
         sorter: true
     },
     {
-        title: 'Reino',
-        type: 'text',
-        key: 'reino',
-        dataIndex: 'reino',
-        sorter: true,
-        width: '15.5%'
-    },
-    {
         title: 'Família',
         key: 'familia',
         dataIndex: 'familia',
@@ -216,7 +208,6 @@ class ListaTaxonomiaSubespecie extends Component {
         subespecie: item.nome,
         acao: this.gerarAcao(item),
         familia: item.familia?.nome,
-        reino: item.reino?.nome,
         genero: item.genero?.nome,
         especie: item.especie?.nome,
         autor: item.autor?.nome

--- a/src/pages/ListaTaxonomiaSubfamilia.jsx
+++ b/src/pages/ListaTaxonomiaSubfamilia.jsx
@@ -28,14 +28,6 @@ const columns = [
         sorter: true
     },
     {
-        title: 'Reino',
-        type: 'text',
-        key: 'reino',
-        dataIndex: 'reino',
-        sorter: true,
-        width: '23.25%'
-    },
-    {
         title: 'Família',
         key: 'familia',
         dataIndex: 'familia',
@@ -63,7 +55,6 @@ class ListaTaxonomiaSubfamilia extends Component {
             subfamilias: [],
             metadados: {},
             familias: [],
-            reinos: [],
             pagina: 1,
             visibleModal: false,
             loadingModal: false,
@@ -125,7 +116,6 @@ class ListaTaxonomiaSubfamilia extends Component {
     componentDidMount() {
         this.requisitaListaSubfamilia({}, this.state.pagina)
         this.requisitaFamilias()
-        this.requisitaReinos()
     }
 
     gerarAcao(item) {
@@ -174,7 +164,6 @@ class ListaTaxonomiaSubfamilia extends Component {
         key: item.id,
         subfamilia: item.nome,
         familia: item.familia?.nome,
-        reino: item.reino?.nome,
         autor: item.autor?.nome,
         acao: this.gerarAcao(item)
     }))
@@ -449,36 +438,10 @@ class ListaTaxonomiaSubfamilia extends Component {
         )
     }
 
-    requisitaReinos = () => {
-        axios.get('/reinos', {
-            params: {
-                limite: 9999999
-            }
-        })
-            .then(response => {
-                if (response.status === 200) {
-                    this.setState({
-                        reinos: response.data.resultado
-                    })
-                }
-            })
-            .catch(err => {
-                const { response } = err
-                if (response && response.data) {
-                    const { error } = response.data
-                    console.error(error.message)
-                }
-            })
-    }
-
     optionFamilia = () => this.state.familias.map(item => (
         <Option value={item.id}>{item.nome}</Option>
     ))
-
-    optionReino = () => this.state.reinos.map(item => (
-        <Option value={item.id}>{item.nome}</Option>
-    ))
-
+    
     renderFormulario() {
         const { getFieldDecorator } = this.props.form
         return (

--- a/src/pages/ListaTaxonomiaVariedade.jsx
+++ b/src/pages/ListaTaxonomiaVariedade.jsx
@@ -28,14 +28,6 @@ const columns = [
         sorter: true
     },
     {
-        title: 'Reino',
-        type: 'text',
-        key: 'reino',
-        dataIndex: 'reino',
-        sorter: true,
-        width: '15.5%'
-    },
-    {
         title: 'Família',
         key: 'familia',
         dataIndex: 'familia',
@@ -194,7 +186,6 @@ class ListaTaxonomiaVariedade extends Component {
         variedade: item.nome,
         acao: this.gerarAcao(item),
         familia: item.familia?.nome,
-        reino: item.reino?.nome,
         genero: item.genero?.nome,
         especie: item.especie?.nome,
         autor: item.autor?.nome


### PR DESCRIPTION
Task: #117 

Retira as colunas de reinos de todas as telas que não seja Reinos e Familia. Retira tambem funções/requisições utilizadas referente a reinos. 