### PR TITLE
Arruma load infinito ao cadastrar variedades e detecção de campos no formulário

### DIFF
--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -341,8 +341,7 @@ class NovoTomboScreen extends Component {
         this.requisitaNumeroHcf()
         this.setState({
             ...this.state,
-            ...dados,
-            familias: []
+            ...dados
         })
 
         if (match.params.tombo_id) {
@@ -1377,10 +1376,10 @@ class NovoTomboScreen extends Component {
         })
             .then(response => {
                 this.setState({
+                    loading: false,
                     search: {
                         variedade: ''
                     }
-                    //  loading: false
                 })
                 if (response.status === 200) {
                     this.setState({


### PR DESCRIPTION
Algumas considerações sobre a tarefa foram feitas no PR das ações que necessitavam de alterações backend: [aqui](https://github.com/utfpr/hcf-api/pull/130)

Sobre o problema da identificação do reino 'Plantae' e, por consequência, a exibição das famílias relacionadas, foi identificado que na função `onRequisitarDadosComSucesso()` havia uma atribuição do estado `familias` onde o valor era um array vazio. Isso fazia com que a familia tivesse o comportamento abaixo:
```js
[] -> [{ dados obtidos do backend }] -> []
``` 

Sobre o problema do loading infinito ao cadastrar variedades, foi observado a falta de `loading: false` quando a requisição é feita com sucesso. Tal atribuição só era feita caso a requisição desse errado.