### PR TITLE
Hotfixes UI - Correções de interface e comportamentos inesperados

### DIFF
--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -2648,6 +2648,22 @@ class NovoTomboScreen extends Component {
         } = this.state
         return (
             <div>
+                {this.props.match.params.tombo_id && ( 
+                    <Row gutter={8} style={{ fontSize: 16, marginLeft: 5 }}>
+                        Editar dados Tombo
+                    </Row>
+                )}
+                <Row justify="end" gutter={8}>
+                    <Button
+                        type="secondary"
+                    >
+                        <Link
+                            to="/tombos"
+                        >
+                            Sair/Cancelar
+                        </Link>
+                    </Button>
+                </Row>
                 <Row gutter={8}>
                     <InputFormField
                         name="numeroTombo"
@@ -3113,125 +3129,118 @@ class NovoTomboScreen extends Component {
                     <br />
                     {' '}
                     <br />
-                    {!this.props.match.params.tombo_id ? (
-                        <>
-                            <Row gutter={8}>
-                                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-                                    <Col span={24}>
-                                        <span> Fotos da exsicata: </span>
-                                    </Col>
-                                    <Col span={24}>
-                                        <FormItem>
-                                            {getFieldDecorator('fotosExsicata')(
-                                                <UploadPicturesComponent
-                                                    fileList={this.state.fotosExsicata}
-                                                    beforeUpload={foto => {
-                                                        this.setState(({ fotosExsicata }) => ({
-                                                            fotosExsicata: [
-                                                                ...fotosExsicata,
-                                                                foto
-                                                            ]
-                                                        }))
+                    <Row gutter={8}>
+                        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                            <Col span={24}>
+                                <span> Fotos da exsicata: </span>
+                            </Col>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('fotosExsicata')(
+                                        <UploadPicturesComponent
+                                            fileList={this.state.fotosExsicata}
+                                            beforeUpload={foto => {
+                                                this.setState(({ fotosExsicata }) => ({
+                                                    fotosExsicata: [
+                                                        ...fotosExsicata,
+                                                        foto
+                                                    ]
+                                                }))
 
-                                                        return false
-                                                    }}
-                                                    onRemove={foto => {
-                                                        this.setState(({ fotosExsicata: listaAntiga }) => {
-                                                            const index = listaAntiga.indexOf(foto)
+                                                return false
+                                            }}
+                                            onRemove={foto => {
+                                                this.setState(({ fotosExsicata: listaAntiga }) => {
+                                                    const index = listaAntiga.indexOf(foto)
 
-                                                            const fotosExsicata = listaAntiga
-                                                                .filter((item, i) => i !== index)
+                                                    const fotosExsicata = listaAntiga
+                                                        .filter((item, i) => i !== index)
 
-                                                            return { fotosExsicata }
-                                                        })
-                                                    }}
-                                                />
-                                            )}
-                                        </FormItem>
-                                    </Col>
-                                </Col>
-                                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-                                    <Col span={24}>
-                                        <span> Fotos em vivo: </span>
-                                    </Col>
-                                    <Col span={24}>
-                                        <FormItem>
-                                            {getFieldDecorator('fotosVivo')(
-                                                <UploadPicturesComponent
-                                                    fileList={this.state.fotosEmVivo}
-                                                    beforeUpload={foto => {
-                                                        this.setState(({ fotosEmVivo }) => ({
-                                                            fotosEmVivo: [
-                                                                ...fotosEmVivo,
-                                                                foto
-                                                            ]
-                                                        }))
+                                                    return { fotosExsicata }
+                                                })
+                                            }}
+                                        />
+                                    )}
+                                </FormItem>
+                            </Col>
+                        </Col>
+                        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                            <Col span={24}>
+                                <span> Fotos em vivo: </span>
+                            </Col>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('fotosVivo')(
+                                        <UploadPicturesComponent
+                                            fileList={this.state.fotosEmVivo}
+                                            beforeUpload={foto => {
+                                                this.setState(({ fotosEmVivo }) => ({
+                                                    fotosEmVivo: [
+                                                        ...fotosEmVivo,
+                                                        foto
+                                                    ]
+                                                }))
 
-                                                        return false
-                                                    }}
-                                                    onRemove={foto => {
-                                                        this.setState(({ fotosEmVivo: listaAntiga }) => {
-                                                            const index = listaAntiga.indexOf(foto)
+                                                return false
+                                            }}
+                                            onRemove={foto => {
+                                                this.setState(({ fotosEmVivo: listaAntiga }) => {
+                                                    const index = listaAntiga.indexOf(foto)
 
-                                                            const fotosEmVivo = listaAntiga
-                                                                .filter((item, i) => i !== index)
+                                                    const fotosEmVivo = listaAntiga
+                                                        .filter((item, i) => i !== index)
 
-                                                            return { fotosEmVivo }
-                                                        })
-                                                    }}
-                                                />
-                                            )}
-                                        </FormItem>
-                                    </Col>
-                                </Col>
-                            </Row>
-                            <br />
-                            <br />
-                            <Row gutter={8}>
-                                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-                                    <Col span={24}>
-                                        <span> Exsicata sem foto: </span>
-                                    </Col>
-                                    <Col span={8}>
-                                        <Button onClick={() => this.criaCodigoBarrasSemFotos(false)}>
-                                            <UploadOutlined />
-                                            {' '}
-                                            Enviar
-                                        </Button>
-                                    </Col>
-                                </Col>
-                                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-                                    <Col span={24}>
-                                        <span> Em vivo sem foto: </span>
-                                    </Col>
-                                    <Col span={8}>
-                                        <Button onClick={() => this.criaCodigoBarrasSemFotos(true)}>
-                                            <UploadOutlined />
-                                            {' '}
-                                            Enviar
-                                        </Button>
-                                    </Col>
-                                </Col>
-                                {/* </div> */}
-                                {/* // : <div></div>} */}
-                            </Row>
-                        </>
-                    ) : (
-                        <>
-                            <Divider dashed />
-                            {this.state.showTable && (
-                                <Row gutter={8}>
-                                    <Table
-                                        columns={this.tabelaFotosColunas}
-                                        dataSource={this.state.fotos}
-                                        loading={this.state.loading}
-                                        rowKey="id"
-                                    />
-                                </Row>
-                            )}
-                        </>
+                                                    return { fotosEmVivo }
+                                                })
+                                            }}
+                                        />
+                                    )}
+                                </FormItem>
+                            </Col>
+                        </Col>
+                    </Row>
+                    <br />
+                    <br />
+                    <Row gutter={8}>
+                        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                            <Col span={24}>
+                                <span> Exsicata sem foto: </span>
+                            </Col>
+                            <Col span={8}>
+                                <Button onClick={() => this.criaCodigoBarrasSemFotos(false)}>
+                                    <UploadOutlined />
+                                    {' '}
+                                    Enviar
+                                </Button>
+                            </Col>
+                        </Col>
+                        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                            <Col span={24}>
+                                <span> Em vivo sem foto: </span>
+                            </Col>
+                            <Col span={8}>
+                                <Button onClick={() => this.criaCodigoBarrasSemFotos(true)}>
+                                    <UploadOutlined />
+                                    {' '}
+                                    Enviar
+                                </Button>
+                            </Col>
+                        </Col>
+                        {/* </div> */}
+                        {/* // : <div></div>} */}
+                    </Row>
+                    <Divider dashed />
+                    {this.state.showTable && this.props.match.params.tombo_id && (
+                        <Row gutter={8}>
+                            <Table
+                                columns={this.tabelaFotosColunas}
+                                dataSource={this.state.fotos}
+                                loading={this.state.loading}
+                                rowKey="id"
+                            />
+                        </Row>
                     )}
-                    <Row type="flex" justify="end" gutter={8}>
+                    <Row type="flex" justify="start" gutter={8}>
                         <Col>
                             <Button
                                 disabled={!this.props.match.params.tombo_id}
@@ -3280,7 +3289,7 @@ class NovoTomboScreen extends Component {
                                 </Link>
                             </Button>
                         </Col>
-                        <Col xs={24} sm={8} md={3} lg={3} xl={3}>
+                        <Col style={{ marginLeft: 'auto' }} xs={24} sm={8} md={3} lg={3} xl={3}>
                             <ButtonComponent titleButton="Salvar" />
                         </Col>
                     </Row>

--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -1890,6 +1890,7 @@ class NovoTomboScreen extends Component {
             tomboId,
             json
         )
+        this.props.history.push('/tombos')
     }
 
     requisitaCadastroTombo = json => {


### PR DESCRIPTION
# PR: Ajustes de UX e Correções no fluxo de Tombos

## Contexto
Este PR melhora a usabilidade e corrige pontos no fluxo de criação/edição de **Tombos**, garantindo navegação consistente e visibilidade correta de dados relacionados ao **Reino** em visualizar informações de um Tombo.

## O que foi feito
- **Botão reposicionado** para a posição esperada no layout (conforme guideline da página).
- **Novo botão “Cancelar/Sair”** para abandonar a operação de forma segura, com confirmação quando houver alterações não salvas.
- **Navegação automática ao concluir** criação/edição: redireciona para a tela adequada (detalhes/listagem) após sucesso.
- **Correção do “Reino” não exibido**: agora seleciona/exibe o primeiro item que corresponde ao `reino_id` do tombo.
- **Botões de upload visíveis na edição**: ações de upload habilitadas também quando o tombo está em modo de edição.

## Mudanças por arquivo
- `src/pages/DetalhesTomboScreen.jsx`  
  - Correção da exibição de Reinos ao visualizar um Tombo, com novo dataFetch de reinos

- `src/pages/tombos/NovoTomboScreen.jsx`  
  - Novo botão **Cancelar/Sair** com confirmação quando houver dirty state.
  - Ajuste do posicionamento dos botões principais.
  - Redirecionamento após salvar (create/update) e feedback visual.
  - Exibição/enable dos botões de upload em modo de edição.

