### PR TITLE
fix: adiciona limitador para 3 fichas tombo

### DIFF
--- a/src/pages/FichaTomboScreen.jsx
+++ b/src/pages/FichaTomboScreen.jsx
@@ -236,7 +236,7 @@ class FichaTomboScreen extends Component {
                     <p>Informe o número de cópias:</p>
                     <InputNumber
                         min={1}
-                        max={50}
+                        max={3}
                         value={this.state.quantidadeCopias}
                         onChange={value => this.setState({ quantidadeCopias: value })}
                     />


### PR DESCRIPTION
Closes #157 

## O que foi feito
Foi adicionado um limitador para que o número de cópias das fichas tombo não ultrapasse 3 cópias cada.