### PR TITLE
Criação de modals e ações para impressão da Ficha Tombo

### DIFF
--- a/src/pages/FichaTomboScreen.jsx
+++ b/src/pages/FichaTomboScreen.jsx
@@ -12,6 +12,7 @@ import { PrinterOutlined, SearchOutlined } from '@ant-design/icons'
 
 import SimpleTableComponent from '../components/SimpleTableComponent'
 import { fichaTomboUrl } from '../config/api'
+import FichaTomboActions from './tombos/components/FichaTomboActions'
 
 const FormItem = Form.Item
 
@@ -93,24 +94,6 @@ class FichaTomboScreen extends Component {
         this.setState({ modalVisible: false })
     }
 
-    geraColunaAcao = tombo => (
-        <div>
-            <Button
-                type="link"
-                icon={<PrinterOutlined style={{ color: '#277a01' }} />}
-                onClick={() => this.abrirModalImpressao(tombo, true)}
-                title="Imprimir ficha com código de barras"
-            />
-            <Divider type="vertical" />
-            <Button
-                type="link"
-                icon={<PrinterOutlined style={{ color: '#0066ff' }} />}
-                onClick={() => this.abrirModalImpressao(tombo, false)}
-                title="Imprimir ficha sem código de barras"
-            />
-        </div>
-    )
-
     geraColunaDataColeta = (...args) => {
         const saida = args.reduce((saida, arg) => {
             if (arg) {
@@ -125,7 +108,7 @@ class FichaTomboScreen extends Component {
 
     formataTomboItem = tombo => ({
         ...tombo,
-        acao: this.geraColunaAcao(tombo),
+        acao: <FichaTomboActions hcf={tombo.hcf} />,
         data_coleta: this.geraColunaDataColeta(tombo.data_coleta_dia, tombo.data_coleta_mes, tombo.data_coleta_ano)
     })
 

--- a/src/pages/ListaTombosScreen.jsx
+++ b/src/pages/ListaTombosScreen.jsx
@@ -21,6 +21,7 @@ import HeaderListComponent from '../components/HeaderListComponent'
 import SimpleTableComponent from '../components/SimpleTableComponent'
 import { baseUrl, recaptchaKey } from '../config/api'
 import { isCuradorOuOperador, isIdentificador } from '../helpers/usuarios'
+import FichaTomboActions from './tombos/components/FichaTomboActions'
 
 const { confirm } = Modal
 const FormItem = Form.Item
@@ -172,8 +173,11 @@ class ListaTombosScreen extends Component {
     gerarAcao(id) {
         if (isCuradorOuOperador()) {
             return [
-                this.renderDetalhes(id),
-                this.renderEditar(id)
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <FichaTomboActions hcf={id} />
+                    {this.renderDetalhes(id)}
+                    {this.renderEditar(id)}
+                </div>
                 // this.renderExcluir(id)
             ]
         }

--- a/src/pages/tombos/components/FichaTomboActions.jsx
+++ b/src/pages/tombos/components/FichaTomboActions.jsx
@@ -1,0 +1,180 @@
+import React, { useState } from 'react'
+
+import {
+    Divider,
+    Button,
+    Modal,
+    Form,
+    InputNumber,
+    Select,
+    Alert,
+    Spin,
+    message
+} from 'antd'
+
+import { PrinterOutlined } from '@ant-design/icons'
+
+import { fichaTomboUrl } from '../../../config/api'
+import { requisitaCodigoBarrasService } from '../TomboService'
+
+const FichaTomboActions = ({ hcf }) => {
+    const [state, setState] = useState({
+        open: false,
+        comCodigo: true,
+        copias: 1
+    })
+
+    const [form] = Form.useForm()
+    const [codigos, setCodigos] = useState([])
+    const [loadingCodigos, setLoadingCodigos] = useState(false)
+    const [printing, setPrinting] = useState(false)
+
+    const abrirModalImpressao = async comCodigo => {
+        setState(s => ({ ...s, open: true, comCodigo }))
+        form.setFieldsValue({
+            copias: 1,
+            codigoSelecionado: undefined
+        })
+
+        if (comCodigo) {
+            setLoadingCodigos(true)
+            try {
+                let response = null
+                const getResponse = resp => { response = resp }
+                await requisitaCodigoBarrasService(getResponse, hcf)
+
+                const lista = response?.data?.map(c => c.codigo_barra) ?? []
+                setCodigos(lista)
+
+                // se vier ao menos um código, pré-seleciona o primeiro
+                if (lista.length > 0) {
+                    form.setFieldsValue({ codigoSelecionado: lista[0] })
+                }
+            } catch (err) {
+                message.error('Não foi possível carregar os códigos de barras.')
+                setCodigos([])
+            } finally {
+                setLoadingCodigos(false)
+            }
+        } else {
+            // sem código, limpa possíveis resíduos
+            setCodigos([])
+        }
+    }
+
+    const fechar = () => {
+        setState(s => ({ ...s, open: false }))
+    }
+
+    const confirmarImpressao = async () => {
+        try {
+            setPrinting(true)
+            const valores = await form.validateFields()
+
+            message.success('Impressão iniciada!')
+            const url = `${fichaTomboUrl}/fichas/tombos/${hcf}/${state.comCodigo ? 1 : 0}`
+                + `?qtd=${valores.copias}&code=${valores.codigoSelecionado}`
+            window.open(url, '_blank')
+            fechar()
+        } catch (e) {
+            message.error('Não foi possível iniciar a impressão.')
+        } finally {
+            setPrinting(false)
+        }
+    }
+
+    return (
+        <div>
+            <Button
+                style={{ width: 'fit-content' }}
+                type="link"
+                icon={<PrinterOutlined style={{ color: '#277a01' }} />}
+                onClick={() => abrirModalImpressao(true)}
+                title="Imprimir ficha com código de barras"
+            />
+            <Divider type="vertical" />
+            <Button
+                style={{ width: 'fit-content' }}
+                type="link"
+                icon={<PrinterOutlined style={{ color: '#0066ff' }} />}
+                onClick={() => abrirModalImpressao(false)}
+                title="Imprimir ficha sem código de barras"
+            />
+            <Divider type="vertical" />
+
+            <Modal
+                title={
+                    state.comCodigo
+                        ? 'Imprimir Ficha Tombo (com código de barras)'
+                        : 'Imprimir Ficha Tombo (sem código de barras)'
+                }
+                open={state.open}
+                onOk={confirmarImpressao}
+                onCancel={fechar}
+                okText="Imprimir"
+                cancelText="Cancelar"
+                confirmLoading={printing}
+                destroyOnClose
+                maskClosable={false}
+            >
+                <div style={{ display: 'grid', gap: 12 }}>
+                    <div>
+                        <strong>Tombo:</strong>
+                        {' '}
+                        {hcf ?? '-'}
+                    </div>
+
+                    <Form
+                        form={form}
+                        layout="vertical"
+                        initialValues={{ copias: 1 }}
+                    >
+                        <Form.Item
+                            name="copias"
+                            label="Quantidade de cópias"
+                            rules={[
+                                { required: true, message: 'Informe a quantidade de cópias' },
+                                {
+                                    validator: (_, v) => (v >= 1 && v <= 3
+                                        ? Promise.resolve()
+                                        : Promise.reject(new Error('Permitido entre 1 e 3')))
+                                }
+                            ]}
+                        >
+                            <InputNumber min={1} max={3} style={{ width: '100%' }} />
+                        </Form.Item>
+
+                        {state.comCodigo && loadingCodigos && (
+                            <Spin tip="Carregando códigos de barras..." />
+                        )}
+                        {state.comCodigo && !loadingCodigos && codigos.length === 0 && (
+                            <Alert
+                                type="warning"
+                                showIcon
+                                message="Nenhum código de barras disponível para este tombo."
+                            />
+                        )}
+                        {state.comCodigo && !loadingCodigos && codigos.length > 0 && (
+                            <Form.Item
+                                name="codigoSelecionado"
+                                label="Código de barras"
+                                rules={[{ required: true, message: 'Selecione um código de barras' }]}
+                            >
+                                <Select
+                                    options={codigos.map(c => ({ value: c, label: c }))}
+                                    placeholder="Selecione o código"
+                                    showSearch
+                                    filterOption={(input, option) => {
+                                        return option?.label.toLowerCase().includes(input.toLowerCase())
+                                    }}
+                                />
+                            </Form.Item>
+                        )}
+                    </Form>
+                </div>
+            </Modal>
+        </div>
+    )
+}
+
+export default FichaTomboActions


### PR DESCRIPTION
## O que foi feito

Closes #164 

Esse PR: 
- Cria um novo componente responsável por mostrar os botões de impressão (com e sem código de barras) e exibe um modal para que o usuário escolha a quantidade de cópias desejadas (limitado a 3 cópias) e o código de barras a ser impresso caso a ação escolhida seja a impressão da ficha tombo com código de barras.
- Adiciona o componente criado na tela de listagem do tombo, facilitando a interação do usuário quando a intenção é a impressão da ficha.
- Muda o componente antigo de impressão da ficha tombo para o componente atual na tela de ficha tombo, o que centraliza as questões relacionadas a impressão em um único componente.