### PR TITLE
fix: mudança no modal de impressão de ficha tombo

### DIFF
--- a/src/pages/tombos/TomboService.jsx
+++ b/src/pages/tombos/TomboService.jsx
@@ -113,7 +113,7 @@ export const requisitaNumeroColetorService = getResponse => {
 }
 
 export const requisitaCodigoBarrasService = (getResponse, tomboId) => {
-    return axios.get(`/tombos/codBarras/${tomboId}`)
+    return axios.get(`/tombos/codigo_barras/${tomboId}`)
         .then(response => {
             getResponse(response)
         })


### PR DESCRIPTION
Aqui está a mudança no endpoint de código de barras, melhorias no modal solicitadas pelo prof. @ipolato e prof. @andreschwerz. Melhorei a verificação do estado de impressão quando se diz respeito a URL também.

Atualmente estou testando a api e a interação dos dados com o que foi desenvolvido sobre a ficha tombo 