### PR TITLE
Feat/196 insere novos filtros relatorio

### DIFF
--- a/src/pages/RelatorioLocalColetaPeriodoScreen.jsx
+++ b/src/pages/RelatorioLocalColetaPeriodoScreen.jsx
@@ -6,7 +6,8 @@ import {
     Button, notification,
     Spin,
     Input,
-    DatePicker
+    DatePicker,
+    Select
 } from 'antd'
 import ptbr from 'antd/es/date-picker/locale/pt_BR'
 import axios from 'axios'
@@ -19,6 +20,7 @@ import { LoadingOutlined } from '@ant-design/icons'
 
 const FormItem = Form.Item
 const { RangePicker } = DatePicker
+const { Option } = Select
 
 const dateFormat = 'DD/MM/YYYY'
 const dateLocale = {
@@ -42,14 +44,146 @@ class RelatorioLocalColetaScreen extends Component {
                 .toISOString(),
             dataFim: moment().endOf('day')
                 .toISOString(),
-            local: null
+            local: null,
+            estados: [],
+            cidades: [],
+            paises: [],
+            locais: []
         }
     }
 
     componentDidMount() {
         const { pagina } = this.state
         this.requisitaDadosDoRelatorio({}, pagina, null, null, true)
+        this.requisitaPaises()
+        this.requisitaListaLocais({}, null)
     }
+
+    requisitaPaises = async () => {
+        try {
+            const response = await axios.get('/paises')
+
+            if (response.status === 200) {
+                const paises = response.data
+                this.setState({
+                    paises
+                })
+
+                const bra = paises.find(p => p.sigla === 'BRA')
+                if (bra) {
+                    this.props.form.setFieldsValue({ pais: bra.id })
+                    this.requisitaEstados(bra.id)
+                }
+            }
+        } catch (err) {
+            this.notificacao('error', 'Erro', 'Falha ao buscar países.')
+        }
+    }
+
+    formataDadosPaises = () => this.state.paises.map(item => (
+        <Option key={item.id} value={item.id}>{item.nome}</Option>
+    ))
+
+    formataDadosEstados = () => this.state.estados.map(item => (
+        <Option key={item.id} value={item.id}>{item.nome}</Option>
+    ))
+
+    formataDadosCidades = () => this.state.cidades.map(item => (
+        <Option key={item.id} value={item.id}>{item.nome}</Option>
+    ))
+
+    formataDadosLocaisOption = () => this.state.locais.map(item => (
+        <Option key={item.key} value={item.nome}>{item.nome}</Option>
+    ))
+
+    requisitaEstados = async paisId => {
+        try {
+            const response = await axios.get('/estados', {
+                params: { id: paisId }
+            })
+
+            if (response.status === 200) {
+                const estados = response.data
+                this.setState({
+                    estados,
+                    cidades: []
+                })
+
+                const parana = estados.find(e => e.sigla === 'PR')
+                if (parana) {
+                    this.props.form.setFieldsValue({ estado: parana.id })
+                    this.requisitaCidades(parana.id)
+                }
+            }
+        } catch (err) {
+            this.notificacao('error', 'Erro', 'Falha ao buscar estados.')
+        }
+    }
+
+    requisitaCidades = async estadoId => {
+        try {
+            const response = await axios.get('/cidades', {
+                params: { id: estadoId }
+            })
+
+            if (response.status === 200) {
+                this.setState({
+                    cidades: response.data
+                })
+            }
+        } catch (err) {
+            this.notificacao('error', 'Erro', 'Falha ao buscar cidades.')
+        }
+    }
+
+    requisitaListaLocais = async (valores, sorter) => {
+        const params = {
+            pagina: 1,
+            limite: 9999
+        }
+
+        if (valores !== undefined) {
+            const { cidade } = valores
+
+            if (cidade) {
+                params.cidade_id = cidade
+            }
+        }
+
+        const campo = sorter && sorter.field ? sorter.field : 'descricao'
+        const ordem = sorter && sorter.order === 'descend' ? 'desc' : 'asc'
+        params.order = `${campo}:${ordem}`
+
+        try {
+            const response = await axios.get('/locais-coleta', { params })
+
+            if (response.status === 200) {
+                const res = this.formataDadosLocais(response.data.resultado)
+                this.setState({
+                    locais: res
+                })
+
+                console.log(res)
+            } else if (response.status === 400) {
+                this.notificacao('warning', 'Buscar locais', 'Erro ao buscar os locais de coleta.')
+                this.setState({ loading: false })
+            } else {
+                this.notificacao('error', 'Erro', 'Erro do servidor ao buscar os locais de coleta.')
+                this.setState({ loading: false })
+            }
+        } catch (err) {
+            this.setState({ loading: false })
+            this.notificacao('error', 'Erro', 'Falha ao buscar locais de coleta.')
+        }
+    }
+
+    formataDadosLocais = locais => locais.map(item => ({
+        key: item.id,
+        nome: item.descricao,
+        pais: item.cidade?.estado?.paise?.nome || '',
+        estado: item.cidade?.estado?.nome || '',
+        cidade: item.cidade?.nome || ''
+    }))
 
     notificacao = (type, titulo, descricao) => {
         notification[type]({
@@ -244,42 +378,151 @@ class RelatorioLocalColetaScreen extends Component {
             <Card title="Filtros do relatório">
                 <Form onSubmit={this.onSubmit}>
                     <Row gutter={8}>
-                        <Col span={24}>
-                            <span>Local:</span>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Col span={24}>
+                                <span>País:</span>
+                            </Col>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('pais')(
+                                        <Select
+                                            defaultValue={this.state.paises.find(item => item.sigla === 'BRA')?.id}
+                                            placeholder="Selecione um país"
+                                            allowClear
+                                            showSearch
+                                            optionFilterProp="children"
+                                            onChange={value => {
+                                                if (value) {
+                                                    this.requisitaEstados(value)
+                                                } else {
+                                                    this.setState({
+                                                        estados: [],
+                                                        cidades: []
+                                                    })
+                                                    this.props.form.setFields({
+                                                        estado: { value: undefined },
+                                                        cidade: { value: undefined }
+                                                    })
+                                                }
+                                            }}
+                                        >
+                                            {this.formataDadosPaises()}
+                                        </Select>
+                                    )}
+                                </FormItem>
+                            </Col>
                         </Col>
-                    </Row>
-                    <Row gutter={8}>
-                        <Col span={24}>
-                            <FormItem>
-                                {getFieldDecorator('local')(
-                                    <Input placeholder="RPPN Moreira Sales" type="text" />
-                                )}
-                            </FormItem>
+
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Col span={24}>
+                                <span>Estado:</span>
+                            </Col>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('estado')(
+                                        <Select
+                                            placeholder="Selecione um estado"
+                                            allowClear
+                                            showSearch
+                                            optionFilterProp="children"
+                                            onChange={value => {
+                                                if (value) {
+                                                    this.requisitaCidades(value)
+                                                } else {
+                                                    this.setState({ cidades: [] })
+                                                    this.props.form.setFields({
+                                                        cidade: { value: undefined }
+                                                    })
+                                                }
+                                            }}
+                                        >
+                                            {this.formataDadosEstados()}
+                                        </Select>
+                                    )}
+                                </FormItem>
+                            </Col>
+                        </Col>
+
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Col span={24}>
+                                <span>Cidade:</span>
+                            </Col>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('cidade')(
+                                        <Select
+                                            placeholder="Selecione uma cidade"
+                                            allowClear
+                                            showSearch
+                                            optionFilterProp="children"
+                                            onChange={value => {
+                                                if (value) {
+                                                    this.requisitaListaLocais({ cidade: value }, null)
+                                                } else {
+                                                    this.requisitaListaLocais({}, null)
+                                                }
+                                            }}
+                                        >
+                                            {this.formataDadosCidades()}
+                                        </Select>
+                                    )}
+                                </FormItem>
+                            </Col>
                         </Col>
                     </Row>
 
-                    <Row gutter={8}>
-                        <Col span={24}>
-                            <span>Intervalo de data:</span>
+                    <Row gutter={8} style={{ marginTop: 16 }}>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Col span={24}>
+                                <span>Local:</span>
+                            </Col>
                         </Col>
                     </Row>
                     <Row gutter={8}>
-                        <Col span={24}>
-                            <FormItem>
-                                {getFieldDecorator('intervaloData')(
-                                    <RangePicker
-                                        defaultValue={[moment().startOf('month'), moment().endOf('day')]}
-                                        format={dateFormat}
-                                        locale={dateLocale}
-                                        onChange={a => {
-                                            this.setState({
-                                                dataInicio: a[0].toISOString(),
-                                                dataFim: a[1].toISOString()
-                                            })
-                                        }}
-                                    />
-                                )}
-                            </FormItem>
+                        <Col xs={24} sm={24} md={24} lg={24} xl={24}>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('local')(
+                                        <Select
+                                            placeholder="Selecione o local de coleta"
+                                            allowClear
+                                            showSearch
+                                            optionFilterProp="children"
+                                        >
+                                            {this.formataDadosLocaisOption()}
+                                        </Select>
+                                    )}
+                                </FormItem>
+                            </Col>
+                        </Col>
+                    </Row>
+
+                    <Row gutter={8} style={{ marginTop: 16 }}>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Col span={24}>
+                                <span>Intervalo de data:</span>
+                            </Col>
+                        </Col>
+                    </Row>
+                    <Row gutter={8}>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Col span={24}>
+                                <FormItem>
+                                    {getFieldDecorator('intervaloData')(
+                                        <RangePicker
+                                            defaultValue={[moment().startOf('month'), moment().endOf('day')]}
+                                            format={dateFormat}
+                                            locale={dateLocale}
+                                            onChange={a => {
+                                                this.setState({
+                                                    dataInicio: a[0].toISOString(),
+                                                    dataFim: a[1].toISOString()
+                                                })
+                                            }}
+                                        />
+                                    )}
+                                </FormItem>
+                            </Col>
                         </Col>
                     </Row>
 


### PR DESCRIPTION
## Feat: insere novos filtros no relatorio por local de coleta

Closes #196 <br/>
## O que foi feito
Essa PR teve o objetivo de adicionar na tela de relatório de locais de coleta três novos campos para filtragem do tipo `select`. Eram eles:
- País
- Estado
- Cidade

O comportamento dado para essa tela foi de que os seletores de país e estado fossem preenchidos com os valores padrões discutidos durante a reunião semanal (Brasil para o seletor de país e Paraná para o seletor de estado). Ainda, o seletor de cidade foi deixado em branco para que o usuário pudesse preencher de acordo com a sua necessidade.

Quando o seletor de cidade ainda não foi preenchido, o campo responsável pelo local de coleta mostra todos os locais independentes da cidade, considerando o país e estado selecionado. Se por algum motivo o usuário não selecionar o campo de estados, os locais de coleta disponíveis levarão em conta somente o país selecionado. Se nenhum dos três campos forem selecionados, os locais disponíveis serão todos os locais cadastrados na plataforma.

Todos os campos do tipo seletor possibilitam que o usuário escreva, aparecendo assim os valores que contem o que ele está escrevendo, melhorando a usabilidade.

## Testes feitos durante o desenvolvimento
Teste 1: Os valores padrão para país e estado devem ser Brasil e Paraná (Gravação de tela)
https://github.com/user-attachments/assets/e807da5e-f306-4923-bc3d-30c2a82603f8

Teste 2: Ao selecionar a  cidade, os locais disponíveis estão relacionados a cidade selecionada
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 13 30 48" src="https://github.com/user-attachments/assets/7c76440b-da5c-46f8-befb-7383ddf819b3" />

Teste 3: Ao mudar o estado, os locais disponíveis estão relacionados ao estado selecionado
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 14 11 26" src="https://github.com/user-attachments/assets/392d1563-740f-45ea-9e29-6c9088451da4" />

Teste 4: Ao deixar somente o país, os locais disponíveis estão relacionados ao país selecionado
Caso 4.1: Brasil
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 14 12 36" src="https://github.com/user-attachments/assets/4719d6d3-df6d-4274-a75c-08f5da4ecad1" />
Caso 4.2: Argentina
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 14 13 52" src="https://github.com/user-attachments/assets/432dd11b-7424-41e0-8eb0-3f59277b2a7f" />

Teste 5: Se não houver coletas naquele local (naquele período de tempo), não há resultados (como antes)
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 13 31 02" src="https://github.com/user-attachments/assets/f1614ba4-937b-4971-bf70-08f2fb26d11b" />

Teste 6: Se houver coletas naquele local (naquele período de tempo), há resultados (como antes)
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 13 31 18" src="https://github.com/user-attachments/assets/b3c611a6-c61f-40cd-87a5-6513a2c011f7" />



