### PR TITLE
Remover coluna numero da tabela de coletor e adicionar index na tabela do tombo

### DIFF
--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -46,7 +46,7 @@ import VegetacaoFormField from './components/VegetacaoFormField'
 import {
     excluirFotoTomboService, atualizarFotoTomboService, criaCodigoBarrasSemFotosService,
     requisitaDadosEdicaoService, requisitaDadosFormularioService, requisitaIdentificadoresPredicaoService,
-    verificaPendenciasService, requisitaNumeroColetorService, requisitaCodigoBarrasService,
+    verificaPendenciasService, requisitaCodigoBarrasService, requisitaNumeroHcfService,
     handleSubmitIdentificadorService
 } from './TomboService'
 
@@ -617,16 +617,6 @@ class NovoTomboScreen extends Component {
                 value: response.data.numero
             }
         })
-    }
-
-    requisitaNumeroColetor = () => {
-        this.defaultRequest(
-            null,
-            requisitaNumeroColetorService,
-            '',
-            'Houve um problema ao buscar o numero de coletor sugerido, tente novamente.',
-            this.onVerificaPendenciasComSucesso
-        )
     }
 
     onRequisitaCodigoBarrasComSucesso = response => {
@@ -2106,7 +2096,7 @@ class NovoTomboScreen extends Component {
         const tomboId = this.props.match.params.tombo_id
         this.defaultRequest(
             null,
-            requisitaNumeroColetorService,
+            requisitaNumeroHcfService,
             'A alteração foi realizada com sucesso.',
             'Houve um problema ao alterar o tombo, tente novamente.',
             this.onRequisitaEdicaoTomboComSucesso,
@@ -2740,7 +2730,6 @@ class NovoTomboScreen extends Component {
                                 this.ajustaColetores(value)
                             }}
                             onClickAddMore={() => {
-                                this.requisitaNumeroColetor()
                                 this.setState({
                                     formulario: {
                                         tipo: 11

--- a/src/pages/tombos/TomboService.jsx
+++ b/src/pages/tombos/TomboService.jsx
@@ -102,16 +102,6 @@ export const verificaPendenciasService = (getResponse, tomboId) => {
         })
 }
 
-export const requisitaNumeroColetorService = getResponse => {
-    return axios.get('/numero-coletores')
-        .then(response => {
-            getResponse(response)
-        })
-        .catch(error => {
-            catchError(error)
-        })
-}
-
 export const requisitaCodigoBarrasService = (getResponse, tomboId) => {
     return axios.get(`/tombos/codigo_barras/${tomboId}`)
         .then(response => {


### PR DESCRIPTION
- Criação de migration para retirar a coluna 'numero' da tabela 'coletores' e criar index na tabela 'tombos' para coletor_id e numero_coleta.
- Apagado referências à coluna numero da tabela coletores em qualquer parte do código.