### PR TITLE
Remover obrigatoriedade do Herbário e Localidade

### DIFF
--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -3074,7 +3074,7 @@ class NovoTomboScreen extends Component {
         )
     }
 
-    renderFamiliaTombo = getFieldDecorator => {
+    renderFamiliaTombo = (getFieldDecorator, getFieldError) => {
         const {
             reinoInicial, familiaInicial, reinos, familias, generoInicial, generos, search,
             especieInicial, especies, subespecieInicial, subespecies,
@@ -3163,6 +3163,7 @@ class NovoTomboScreen extends Component {
                         initialValue={String(familiaInicial)}
                         familias={familias}
                         getFieldDecorator={getFieldDecorator}
+                        getFieldError={getFieldError}
                         onChange={value => {
                             this.requisitaSubfamilias(value)
                             this.requisitaGeneros(value)
@@ -3549,7 +3550,7 @@ class NovoTomboScreen extends Component {
                             <h2 style={{ fontWeight: 200 }}>Tombo</h2>
                         </Col>
                     </Row>
-                    {this.renderFamiliaTombo(getFieldDecorator)}
+                    {this.renderFamiliaTombo(getFieldDecorator, getFieldError)}
                     <Divider dashed />
                     {this.renderColetores(getFieldDecorator, getFieldError)}
                     <Divider dashed />
@@ -3849,15 +3850,25 @@ class NovoTomboScreen extends Component {
                     <Col xs={24} sm={24} md={8} lg={8} xl={8}>
                         <Col span={24}>
                             <span>Localidade:</span>
+                            <Button 
+                                type="text" 
+                                onClick={() => {
+                                    this.props.form.setFieldsValue({ localidadeCor: undefined })
+                                }}
+                                style={{ 
+                                    color: '#999', 
+                                    fontSize: '12px',
+                                    padding: '0 4px',
+                                    height: 'auto'
+                                }}
+                            >
+                                Limpar
+                            </Button>
                         </Col>
                         <Col span={24}>
                             <FormItem>
                                 {getFieldDecorator('localidadeCor', {
                                     initialValue: String(this.state.localidadeInicial),
-                                    rules: [{
-                                        required: true,
-                                        message: 'Escolha uma localidade'
-                                    }]
                                 })(
                                     <RadioGroup
                                         onChange={this.onChange}
@@ -3900,15 +3911,12 @@ class NovoTomboScreen extends Component {
                             <FormItem>
                                 {getFieldDecorator('entidade', {
                                     initialValue: String(!this.props.match.params.tombo_id ? this.state.herbarioInicial?.value || '' : this.state.herbarioInicial),
-                                    rules: [{
-                                        required: true,
-                                        message: 'Escolha uma entidade'
-                                    }]
                                 })(
                                     <Select
                                         showSearch
                                         placeholder="Selecione uma entidade"
                                         optionFilterProp="children"
+                                        allowClear
                                         status={getFieldError('entidade') ? 'error' : ''}
                                     >
                                         {this.optionEntidades()}

--- a/src/pages/tombos/components/FamiliaFormField.jsx
+++ b/src/pages/tombos/components/FamiliaFormField.jsx
@@ -7,7 +7,7 @@ import SelectedFormFiled from './SelectedFormFiled'
 const { Option } = Select
 
 const FamiliaFormField = ({
-    initialValue, familias, getFieldDecorator, onClickAddMore, onChange
+    initialValue, familias, getFieldDecorator, onClickAddMore, onChange, getFieldError
 }) => {
     const optionFamilia = () => familias?.map(item => (
         <Option value={`${item.id}`}>{item.nome}</Option>
@@ -24,9 +24,11 @@ const FamiliaFormField = ({
             placeholder="Selecione uma família"
             fieldName="familia"
             getFieldDecorator={getFieldDecorator}
+            getFieldError={getFieldError}
             onClickAddMore={onClickAddMore}
             onChange={onChange}
             others={{allowClear: true}}
+            rules={[{ required: true, message: 'Escolha uma família' }]}
         >
             {optionFamilia()}
         </SelectedFormFiled>


### PR DESCRIPTION
- Removido a obrigatoriedade do campo do Herbário e do campo localidade
- Nova opção para limpar input de herbário
<img width="816" height="94" alt="image" src="https://github.com/user-attachments/assets/8b1ef777-7c0c-457f-9ba4-b378c13268f5" />

- Nova opção para limpar o input de localidade
<img width="368" height="66" alt="image" src="https://github.com/user-attachments/assets/52209220-9b5d-4af2-a0e1-623f37b02ad0" />

- Adicionado mensagem de obrigatoriedade do input de família. 