### PR TITLE
Removendo o cálculo do número hcf de tombos do Frontend

### DIFF
--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -1093,7 +1093,7 @@ class NovoTomboScreen extends Component {
 
     requisitaNumeroHcf = () => {
         axios
-            .get('/tombos/filtrar_ultimo_numero')
+            .get('/tombos/proximo_numero')
             .then(response => {
                 if (response.status === 200) {
                     if (this.props.match.params.tombo_id) {
@@ -1118,10 +1118,10 @@ class NovoTomboScreen extends Component {
                             this.props.match.params.tombo_id
                         )
                     } else {
-                        this.setState({ numeroHcf: Number(response.data.hcf) + 1 })
+                        this.setState({ numeroHcf: response.data.hcf})
                         this.props.form.setFields({
                             numeroTombo: {
-                                value: Number(response.data.hcf) + 1
+                                value: Number(response.data.hcf)
                             }
                         })
                         const date = new Date()

--- a/src/pages/tombos/TomboService.jsx
+++ b/src/pages/tombos/TomboService.jsx
@@ -143,7 +143,17 @@ export const requisitaCadastroTomboService = (getResponse, json) => {
 }
 
 export const requisitaNumeroHcfService = getResponse => {
-    return axios.get('/tombos/filtrar_ultimo_numero')
+    return axios.get('/tombos/proximo_numero')
+        .then(response => {
+            getResponse(response)
+        })
+        .catch(error => {
+            catchError(error)
+        })
+}
+
+export const requisitaProximoNumeroHcfService = getResponse => {
+    return axios.get('/tombos/proximo_numero')
         .then(response => {
             getResponse(response)
         })

--- a/src/pages/tombos/TomboService.jsx
+++ b/src/pages/tombos/TomboService.jsx
@@ -152,16 +152,6 @@ export const requisitaNumeroHcfService = getResponse => {
         })
 }
 
-export const requisitaProximoNumeroHcfService = getResponse => {
-    return axios.get('/tombos/proximo_numero')
-        .then(response => {
-            getResponse(response)
-        })
-        .catch(error => {
-            catchError(error)
-        })
-}
-
 export const requisitaEstadosService = (getResponse, id) => {
     return axios.get('/estados', {
         params: {


### PR DESCRIPTION
Removendo o cálculo do número hcf de tombos do front e criando uma requisição para pegar o numero da api.