### PR TITLE
Botão 'Gerar código' com design 'outlined'

### DIFF
--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -70,6 +70,21 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+.botao-gerar-codigo {
+    display: inline-flex;
+    align-items: center;
+
+    background: transparent;
+    color: #007A33;
+    border-color: #007A33;
+
+    &:hover,
+    &:focus {
+        color: #009944;
+        border-color: #009944;
+    }
+}
+
 /* Responsividade para diferentes tamanhos de tela */
 @media (max-width: 768px) {
   .contentForm {

--- a/src/components/BarcodeTableComponent.jsx
+++ b/src/components/BarcodeTableComponent.jsx
@@ -752,17 +752,10 @@ export default class BarcodeTableComponent extends Component {
                         }}
                     >
                         <Button
+                            className="botao-gerar-codigo"
                             icon={<PlusOutlined />}
                             loading={isGenerating}
                             onClick={this.handleOpenGenerationModal}
-                            style={{
-                                display: 'inline-flex',
-                                alignItems: 'center',
-                                backgroundColor: 'transparent',
-                                color: '#007A33',      
-                                borderColor: '#007A33',  
-                                borderStyle: 'solid'
-                            }}
                         >
                             Gerar código
                         </Button>

--- a/src/components/BarcodeTableComponent.jsx
+++ b/src/components/BarcodeTableComponent.jsx
@@ -752,10 +752,17 @@ export default class BarcodeTableComponent extends Component {
                         }}
                     >
                         <Button
-                            type="primary"
                             icon={<PlusOutlined />}
                             loading={isGenerating}
                             onClick={this.handleOpenGenerationModal}
+                            style={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                backgroundColor: 'transparent',
+                                color: '#007A33',      
+                                borderColor: '#007A33',  
+                                borderStyle: 'solid'
+                            }}
                         >
                             Gerar código
                         </Button>


### PR DESCRIPTION
O botão "Gerar código", que antes estava com o mesmo design do botão "Salvar", na tela de adicionar tombo, agora está com um estilo diferente, a fim de evitar equívocos. 
Antes estava preenchido em verde, com o símbolo e o texto em branco, agora está "contornado", tendo o símbolo e o texto em verde. 