### PR TITLE
feat: aciona validação de cidade na edição de lat/long com debounce

### DIFF
--- a/src/pages/tombos/NovoTomboScreen.jsx
+++ b/src/pages/tombos/NovoTomboScreen.jsx
@@ -3417,6 +3417,20 @@ class NovoTomboScreen extends Component {
         }
     }
 
+    handleCoordenadaChange = () => {
+        clearTimeout(this._coordenadaDebounceTimer)
+        this._coordenadaDebounceTimer = setTimeout(() => {
+            const { form } = this.props
+            const cidade = form.getFieldValue('cidade')
+            const latitude = form.getFieldValue('latitude')
+            const longitude = form.getFieldValue('longitude')
+
+            if (cidade && latitude != null && latitude !== '' && longitude != null && longitude !== '') {
+                this.verifyCoordenada()
+            }
+        }, 500)
+    }
+
     validacaoModal = () => {
         if (this.state.formColetor) {
             if (
@@ -3765,7 +3779,7 @@ class NovoTomboScreen extends Component {
         return (
             <div>
                 <Row gutter={8}>
-                    <LatLongFormField getFieldDecorator={getFieldDecorator} form={this.props.form} />
+                    <LatLongFormField getFieldDecorator={getFieldDecorator} form={this.props.form} onCoordenadaChange={this.handleCoordenadaChange} />
                 </Row>
                 <br />
                 <Row gutter={8}>

--- a/src/pages/tombos/components/LatLongFormField.jsx
+++ b/src/pages/tombos/components/LatLongFormField.jsx
@@ -16,7 +16,7 @@ const validaCoordenadaDecimal = (valor, isLongitude) => {
     return valor >= -maxValor && valor <= maxValor
 }
 
-const LatLongFormField = ({ getFieldDecorator, form }) => {
+const LatLongFormField = ({ getFieldDecorator, form, onCoordenadaChange }) => {
     // Validador customizado para latitude
     const validadorLatitude = (rule, value, callback) => {
         const longitude = form?.getFieldValue('longitude')
@@ -76,7 +76,12 @@ const LatLongFormField = ({ getFieldDecorator, form }) => {
                         {getFieldDecorator('latitude', {
                             rules: [
                                 { validator: validadorLatitude }
-                            ]
+                            ],
+                            onChange: () => {
+                                if (typeof onCoordenadaChange === 'function') {
+                                    onCoordenadaChange()
+                                }
+                            }
                         })(
                             <CoordenadaInputText
                                 placeholder={'48°40\'30"O'}
@@ -94,7 +99,12 @@ const LatLongFormField = ({ getFieldDecorator, form }) => {
                         {getFieldDecorator('longitude', {
                             rules: [
                                 { validator: validadorLongitude }
-                            ]
+                            ],
+                            onChange: () => {
+                                if (typeof onCoordenadaChange === 'function') {
+                                    onCoordenadaChange()
+                                }
+                            }
                         })(
                             <CoordenadaInputText
                                 longitude


### PR DESCRIPTION
## Objetivo
Garantir que o aviso de validação (coordenada vs. cidade) seja atualizado caso o usuário corrija os campos de Latitude ou Longitude, e não apenas no momento em que a Cidade é selecionada.

## O que foi feito
* **`LatLongFormField.jsx`**: Prop `onCoordenadaChange` adicionada para capturar alterações em qualquer subcampo (graus, minutos, segundos, direção) e repassar ao componente pai.
* **`NovoTomboScreen.jsx`**: 
  * Criado o método `handleCoordenadaChange` com *debounce* de 500ms (usando a instância da classe para evitar *re-renders* extras).
  * Adicionada regra de bloqueio: a validação `verifyCoordenada()` agora só é disparada quando Cidade, Latitude e Longitude estão totalmente preenchidos.

##  O bug que isso resolve
Antes, se o usuário selecionasse a cidade, digitasse a coordenada errada e recebesse o *warning*, o aviso não sumia ao corrigir a coordenada, pois a validação não escutava as mudanças de Lat/Lng. Agora o feedback visual é reativo e reflete o estado real dos campos.