### PR TITLE
Correção do Painel que não Carregava por conta do i18n

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -20,11 +20,7 @@ void i18n
         'navigator',
         'localStorage'
       ],
-      caches: [
-        'path',
-        'navigator',
-        'localStorage'
-      ]
+      caches: ['localStorage']
     },
     backend: {
       loadPath: '/locales/{{lng}}/{{ns}}.json'


### PR DESCRIPTION
O erro consistia em algumas opções listadas em "cache" que não conseguiam entregar essa funcionalidade. 

Removi elas e deixei apenas "localStorage", que é o mais utilizado, a fim de que, caso o usuário troque de linguagem, isso ficará salvo no navegador dele e evitará requisições redundantes, tanto ao abrir o site, quanto ao navegar por ele.  