### PR TITLE
Renderização Errada das Colunas

### DIFF
--- a/src/pages/ListaTombosScreen.jsx
+++ b/src/pages/ListaTombosScreen.jsx
@@ -863,7 +863,7 @@ class ListaTombosScreen extends Component {
                 {this.renderPainelBusca(getFieldDecorator)}
                 <Divider dashed />
                 <SimpleTableComponent
-                    columns={buildColumns(this.props.t)}
+                    columns={columns}
                     data={this.state.tombos}
                     metadados={this.state.metadados}
                     loading={this.state.loading}


### PR DESCRIPTION
Havia um erro na linha que fazia a renderização das colunas no arquivo ListaTombosScreen.jsx. 

Apenas voltei para como eu encontrei essa linha em uma versão mais antiga do projeto.